### PR TITLE
Allow NavigatorIOS to define routes' `passProps` property as a function.

### DIFF
--- a/Libraries/Components/Navigation/NavigatorIOS.ios.js
+++ b/Libraries/Components/Navigation/NavigatorIOS.ios.js
@@ -11,6 +11,7 @@
  */
 'use strict';
 
+var _ = require('underscore');
 var EventEmitter = require('EventEmitter');
 var Image = require('Image');
 var NavigationContext = require('NavigationContext');
@@ -53,7 +54,7 @@ var NavigatorTransitionerIOS = React.createClass({
 type Route = {
   component: Function;
   title: string;
-  passProps?: Object;
+  passProps?: any;
   backButtonTitle?: string;
   backButtonIcon?: Object;
   leftButtonTitle?: string;
@@ -202,7 +203,7 @@ var NavigatorIOS = React.createClass({
        * Specify additional props passed to the component. NavigatorIOS will
        * automatically provide "route" and "navigator" components
        */
-      passProps: PropTypes.object,
+      passProps: PropTypes.any,
 
       /**
        * If set, the left header button image will appear with this source. Note
@@ -651,6 +652,18 @@ var NavigatorIOS = React.createClass({
     var shouldUpdateChild =
       this.state.updatingAllIndicesAtOrBeyond != null &&
       this.state.updatingAllIndicesAtOrBeyond >= i;
+
+    if (typeof passProps == "function") {
+      let newPassProps = passProps();
+
+      if (_.isEqual(newPassProps, route.lastPassProps)) {
+        passProps = route.lastPassProps;
+      } else {
+        passProps = route.lastPassProps = newPassProps;
+        shouldUpdateChild = true;
+      }
+    }
+
     var Component = component;
     return (
       <StaticContainer key={'nav' + i} shouldUpdate={shouldUpdateChild}>


### PR DESCRIPTION
- Allows internal scenes to react to changes in their passed properties.
- By default, NavigatorIOS (and Navigator, to a lesser extent) doesn't play
  super nicely with flux's concept of unidirectional data flow. When a property
  in a route's `passProps` changes, the route's scene is not re-rendered.
- This patch allows route objects to optionally define their `passProps`
  property as a function that returns an hash of properties to use for
  rendering.
- When a route's `passProps` property is a function, it will be evaluated each
  time NavigatorIOS is rendered. If the properties have changed, the route's
  scene will be re-rendered with the new properties.
- Workaround for design decision described [here](https://github.com/facebook/react-native/issues/795).
- Some folks are putting resources into figuring out a better process to accomplish single-directional
  data flow with navigation components & patterns. I think we'll eventually be able to take advantage
  of that work. GitHub repo for that project is [here](https://github.com/ericvicenti/navigation-rfc).
