### PR TITLE
fix for android text being cutoff

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -269,7 +269,7 @@ public class ReactTextShadowNode extends LayoutShadowNode {
                 ? Math.min(reactCSSNode.mNumberOfLines, layout.getLineCount())
                 : layout.getLineCount();
             float lineHeight = PixelUtil.toPixelFromSP(reactCSSNode.mLineHeight);
-            measureOutput.height = lineHeight * lines;
+            measureOutput.height = layout.getLineCount() == 1 ? layout.getHeight() : lineHeight * lines;
           }
         }
       };


### PR DESCRIPTION
This is a fix for https://github.com/bjornco/Fam/issues/172. Basically `ReactAndroid` has a few ways of determining height for a `TextView`. The primary way is to use `textView.layout.getHeight()`, however if the `TextView` has a `lineHeight` applied to it then React uses `lineHeight * numOfLines` and, for some reason which I'm not totally clear on, for single lines the height based on lineHeight is less than the height reported from layout, which causes the text to get cut off.

The workaround I've added makes it so the app uses `layout.getHeight()` if the text is a single line.
